### PR TITLE
Add custom memory management to keep track of total amount of memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Duktape bindings for Go(Golang) [![wercker status](https://app.wercker.com/status/1ce7671d7223880e967bf8a81b96341d/s/master "wercker status")](https://app.wercker.com/project/bykey/1ce7671d7223880e967bf8a81b96341d)
+# Duktape bindings for Go(Golang)
 [Duktape](http://duktape.org/index.html) is a thin, embeddable javascript engine.
 Most of the [api](http://duktape.org/api.html) is implemented.
 The exceptions are listed [here](https://github.com/olebedev/go-duktape/blob/master/api.go#L1294).
@@ -11,7 +11,7 @@ import "fmt"
 import "github.com/olebedev/go-duktape"
 
 func main() {
-  ctx := duktape.NewContext()
+  ctx := duktape.NewContext(0)
   ctx.EvalString(`2 + 3`)
   result := ctx.GetNumber(-1)
   ctx.Pop()
@@ -30,7 +30,7 @@ import "fmt"
 import "github.com/olebedev/go-duktape"
 
 func main() {
-  ctx := duktape.NewContext()
+  ctx := duktape.NewContext(0)
   ctx.PushGofunc("log", func(ctx *duktape.Context) int {
     fmt.Println("Go lang Go!")
     return 0

--- a/api.go
+++ b/api.go
@@ -125,7 +125,10 @@ static duk_idx_t _duk_push_error_object(duk_context *ctx, duk_errcode_t err_code
 }
 */
 import "C"
-import "unsafe"
+import (
+	"runtime"
+	"unsafe"
+)
 
 // See: http://duktape.org/api.html#duk_alloc
 func (d *Context) Alloc(size int) {
@@ -260,6 +263,11 @@ func (d *Context) DelPropString(objIndex int, key string) bool {
 // See: http://duktape.org/api.html#duk_destroy_heap
 func (d *Context) DestroyHeap() {
 	C.duk_destroy_heap(d.duk_context)
+	if p, ok := allocMap.Load(d); ok {
+		C.free(p.(unsafe.Pointer))
+		allocMap.Delete(d)
+	}
+	runtime.SetFinalizer(d, nil)
 }
 
 // See: http://duktape.org/api.html#duk_dump_context_stderr

--- a/api.go
+++ b/api.go
@@ -263,7 +263,7 @@ func (d *Context) DelPropString(objIndex int, key string) bool {
 // See: http://duktape.org/api.html#duk_destroy_heap
 func (d *Context) DestroyHeap() {
 	C.duk_destroy_heap(d.duk_context)
-	if p, ok := allocMap.Load(d); ok {
+	if p, ok := allocMap.Load(d.duk_context); ok {
 		C.free(p.(unsafe.Pointer))
 		allocMap.Delete(d)
 	}

--- a/duktape.go
+++ b/duktape.go
@@ -7,11 +7,15 @@ package duktape
 extern duk_ret_t goFinalize(duk_context *ctx);
 extern duk_ret_t goCall(duk_context *ctx);
 extern void goFatalError(void* udata, int code, char* msg);
+extern void* goAlloc(void* udata, duk_size_t size);
+extern void* goRealloc(void* udata, void* ptr, duk_size_t size);
+extern void goFree(void* udata, void* ptr);
 */
 import "C"
 import (
 	"errors"
 	"log"
+	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -95,17 +99,46 @@ func (t Type) IsPointer() bool   { return t == DUK_TYPE_POINTER }
 
 var objectMutex sync.Mutex
 var objectMap map[unsafe.Pointer]interface{} = make(map[unsafe.Pointer]interface{})
+var allocMap sync.Map // key: *Context, value: unsafe.Pointer (alloc_udata)
 
 type Context struct {
 	duk_context unsafe.Pointer
 }
 
 // Returns initialized duktape context object
-func NewContext() *Context {
-	ctx := &Context{
-		// TODO: "A caller SHOULD implement a fatal error handler in most applications."
-		duk_context: C.duk_create_heap(nil, nil, nil, nil, (*[0]byte)(C.goFatalError)),
+func NewContext(maxHeapSize uint64) *Context {
+	var udata unsafe.Pointer = nil
+	if maxHeapSize > 0 {
+		hdrSize := C.size_t(unsafe.Sizeof(C.size_t(0))) * 2
+		udata = C.malloc(hdrSize)
+		if udata != nil {
+			arr := (*[2]C.size_t)(udata)
+			arr[0] = 0                     // total_allocated
+			arr[1] = C.size_t(maxHeapSize) // max_allocated
+		}
 	}
+
+	var dukCtx unsafe.Pointer
+	if udata != nil {
+		dukCtx = C.duk_create_heap((*[0]byte)(C.goAlloc), (*[0]byte)(C.goRealloc), (*[0]byte)(C.goFree), udata, (*[0]byte)(C.goFatalError))
+	} else {
+		dukCtx = C.duk_create_heap(nil, nil, nil, nil, (*[0]byte)(C.goFatalError))
+	}
+
+	ctx := &Context{
+		duk_context: dukCtx,
+	}
+	allocMap.Store(ctx, udata)
+
+	if udata != nil {
+		runtime.SetFinalizer(ctx, func(c *Context) {
+			if p, ok := allocMap.Load(c); ok {
+				C.free(p.(unsafe.Pointer))
+				allocMap.Delete(c)
+			}
+		})
+	}
+
 	return ctx
 }
 
@@ -234,6 +267,111 @@ func (d *Context) EvalWith(source string, suite MethodSuite) error {
 //export goFatalError
 func goFatalError(udata unsafe.Pointer, code C.int, msg *C.char) {
 	log.Panicf("duktape fatal: [%d] %s", code, C.GoString(msg))
+}
+
+//export goAlloc
+func goAlloc(udata unsafe.Pointer, size C.duk_size_t) unsafe.Pointer {
+	if size == 0 {
+		return nil
+	}
+
+	hdrSize := C.size_t(unsafe.Sizeof(C.size_t(0)))
+
+	if udata != nil {
+		arr := (*[2]C.size_t)(udata)
+		total_allocated := arr[0]
+		max_allocated := arr[1]
+		if max_allocated > 0 && total_allocated+C.size_t(size) > max_allocated {
+			return nil
+		}
+	}
+
+	raw := C.malloc(C.size_t(size) + hdrSize)
+	if raw == nil {
+		return nil
+	}
+
+	header := (*C.size_t)(raw)
+	*header = C.size_t(size)
+
+	if udata != nil {
+		arr := (*[2]C.size_t)(udata)
+		arr[0] += C.size_t(size) // total_allocated
+	}
+
+	return unsafe.Pointer(uintptr(raw) + uintptr(hdrSize))
+}
+
+//export goRealloc
+func goRealloc(udata unsafe.Pointer, ptr unsafe.Pointer, size C.duk_size_t) unsafe.Pointer {
+	hdrSize := C.size_t(unsafe.Sizeof(C.size_t(0)))
+
+	if ptr == nil {
+		return goAlloc(udata, size)
+	}
+
+	raw := unsafe.Pointer(uintptr(ptr) - uintptr(hdrSize))
+	header := (*C.size_t)(raw)
+	old := *header
+
+	if size == 0 {
+		if udata != nil {
+			arr := (*[2]C.size_t)(udata)
+			if arr[0] >= old {
+				arr[0] -= old
+			} else {
+				arr[0] = 0
+			}
+		}
+		C.free(raw)
+		return nil
+	}
+
+	if udata != nil {
+		arr := (*[2]C.size_t)(udata)
+		total_allocated := arr[0]
+		max_allocated := arr[1]
+		if max_allocated > 0 && total_allocated-old+C.size_t(size) > max_allocated {
+			return nil
+		}
+	}
+
+	t := C.realloc(raw, C.size_t(size)+hdrSize)
+	if t == nil {
+		return nil
+	}
+
+	header = (*C.size_t)(t)
+	*header = C.size_t(size)
+	if udata != nil {
+		arr := (*[2]C.size_t)(udata)
+		if arr[0] >= old {
+			arr[0] = arr[0] - old + C.size_t(size)
+		} else {
+			arr[0] = C.size_t(size)
+		}
+	}
+	return unsafe.Pointer(uintptr(t) + uintptr(hdrSize))
+}
+
+//export goFree
+func goFree(udata unsafe.Pointer, ptr unsafe.Pointer) {
+	if ptr == nil {
+		return
+	}
+	hdrSize := C.size_t(unsafe.Sizeof(C.size_t(0)))
+	raw := unsafe.Pointer(uintptr(ptr) - uintptr(hdrSize))
+	header := (*C.size_t)(raw)
+	old := *header
+	if udata != nil {
+		arr := (*[2]C.size_t)(udata)
+		if arr[0] >= old {
+			arr[0] -= old
+		} else {
+			arr[0] = 0
+		}
+	}
+	C.free(raw)
 }
 
 // TBD: panic handling.

--- a/duktape.go
+++ b/duktape.go
@@ -128,9 +128,10 @@ func NewContext(maxHeapSize uint64) *Context {
 	ctx := &Context{
 		duk_context: dukCtx,
 	}
-	allocMap.Store(ctx, udata)
 
 	if udata != nil {
+		allocMap.Store(ctx, udata)
+
 		runtime.SetFinalizer(ctx, func(c *Context) {
 			if p, ok := allocMap.Load(c); ok {
 				C.free(p.(unsafe.Pointer))

--- a/duktape.go
+++ b/duktape.go
@@ -99,7 +99,7 @@ func (t Type) IsPointer() bool   { return t == DUK_TYPE_POINTER }
 
 var objectMutex sync.Mutex
 var objectMap map[unsafe.Pointer]interface{} = make(map[unsafe.Pointer]interface{})
-var allocMap sync.Map // key: *Context, value: unsafe.Pointer (alloc_udata)
+var allocMap sync.Map // key: unsafe.Pointer (duk_context), value: unsafe.Pointer (alloc_udata)
 
 type Context struct {
 	duk_context unsafe.Pointer
@@ -130,12 +130,12 @@ func NewContext(maxHeapSize uint64) *Context {
 	}
 
 	if udata != nil {
-		allocMap.Store(ctx, udata)
+		allocMap.Store(ctx.duk_context, udata)
 
 		runtime.SetFinalizer(ctx, func(c *Context) {
-			if p, ok := allocMap.Load(c); ok {
+			if p, ok := allocMap.Load(c.duk_context); ok {
 				C.free(p.(unsafe.Pointer))
-				allocMap.Delete(c)
+				allocMap.Delete(c.duk_context)
 			}
 		})
 	}

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -24,7 +24,8 @@ func TestEvalString(t *testing.T) {
 func TestEvalFunc(t *testing.T) {
 	ctx := NewContext(0)
 	defer ctx.DestroyHeap()
-	ctx.PevalString(`(function (x) { return x + x; })`)
+	err := ctx.PevalString(`(function (x) { return x + x; })`)
+	expect(t, err, 0)
 	expect(t, ctx.IsCallable(-1), true)
 	expect(t, Type(ctx.GetType(-1)).IsObject(), true)
 	ctx.PushInt(5)

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -5,25 +5,26 @@ import "testing"
 
 func TestEvalString(t *testing.T) {
 	ctx := NewContext(0)
+	defer ctx.DestroyHeap()
 	ctx.EvalString(`"Golang love Duktape!"`)
 	expect(t, Type(ctx.GetType(-1)).IsString(), true)
 	expect(t, ctx.GetString(-1), "Golang love Duktape!")
-	ctx.DestroyHeap()
 }
 
 func TestEvalFunc(t *testing.T) {
 	ctx := NewContext(0)
+	defer ctx.DestroyHeap()
 	ctx.PevalString(`(function (x) { return x + x; })`)
 	expect(t, ctx.IsCallable(-1), true)
 	expect(t, Type(ctx.GetType(-1)).IsObject(), true)
 	ctx.PushInt(5)
 	ctx.Pcall(1)
 	expect(t, ctx.GetInt(-1), 10)
-	ctx.DestroyHeap()
 }
 
 func TestEvalWith(t *testing.T) {
 	ctx := NewContext(0)
+	defer ctx.DestroyHeap()
 
 	obj := MethodSuite{
 		"hi": func(d *Context) int {
@@ -38,8 +39,6 @@ func TestEvalWith(t *testing.T) {
 	actual := ctx.GetString(-1)
 
 	expect(t, actual, "hi! 2")
-
-	ctx.DestroyHeap()
 }
 
 // from duktape examples
@@ -56,6 +55,7 @@ func TestMyAddTwo(t *testing.T) {
 	}
 
 	ctx := NewContext(0)
+	defer ctx.DestroyHeap()
 	ctx.PushGlobalObject()
 
 	// Hmm... a property value can outlive an object. look out!
@@ -67,7 +67,6 @@ func TestMyAddTwo(t *testing.T) {
 	res := ctx.GetNumber(-1)
 	ctx.Pop()
 	expect(t, res, float64(5))
-	ctx.DestroyHeap()
 }
 
 func TestGoClosure(t *testing.T) {
@@ -86,6 +85,7 @@ func TestGoClosure(t *testing.T) {
 	}
 
 	ctx := NewContext(0)
+	defer ctx.DestroyHeap()
 
 	ctx.EvalWith(`
             (function(o) {
@@ -101,7 +101,6 @@ func TestGoClosure(t *testing.T) {
 	ctx.Gc(0)
 	ctx.Gc(0)
 	expect(t, len(objectMap), 0)
-	ctx.DestroyHeap()
 }
 
 type SampleObject struct {
@@ -110,6 +109,7 @@ type SampleObject struct {
 
 func TestGoObject(t *testing.T) {
 	ctx := NewContext(0)
+	defer ctx.DestroyHeap()
 	ctx.PushGlobalObject()
 	ctx.PushGoObject(SampleObject{42})
 	ctx.PutPropString(-2, "y")

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -4,7 +4,7 @@ import "reflect"
 import "testing"
 
 func TestEvalString(t *testing.T) {
-	ctx := NewContext()
+	ctx := NewContext(0)
 	ctx.EvalString(`"Golang love Duktape!"`)
 	expect(t, Type(ctx.GetType(-1)).IsString(), true)
 	expect(t, ctx.GetString(-1), "Golang love Duktape!")
@@ -12,7 +12,7 @@ func TestEvalString(t *testing.T) {
 }
 
 func TestEvalFunc(t *testing.T) {
-	ctx := NewContext()
+	ctx := NewContext(0)
 	ctx.PevalString(`(function (x) { return x + x; })`)
 	expect(t, ctx.IsCallable(-1), true)
 	expect(t, Type(ctx.GetType(-1)).IsObject(), true)
@@ -23,7 +23,7 @@ func TestEvalFunc(t *testing.T) {
 }
 
 func TestEvalWith(t *testing.T) {
-	ctx := NewContext()
+	ctx := NewContext(0)
 
 	obj := MethodSuite{
 		"hi": func(d *Context) int {
@@ -55,7 +55,7 @@ func TestMyAddTwo(t *testing.T) {
 		},
 	}
 
-	ctx := NewContext()
+	ctx := NewContext(0)
 	ctx.PushGlobalObject()
 
 	// Hmm... a property value can outlive an object. look out!
@@ -85,7 +85,7 @@ func TestGoClosure(t *testing.T) {
 		},
 	}
 
-	ctx := NewContext()
+	ctx := NewContext(0)
 
 	ctx.EvalWith(`
             (function(o) {
@@ -109,7 +109,7 @@ type SampleObject struct {
 }
 
 func TestGoObject(t *testing.T) {
-	ctx := NewContext()
+	ctx := NewContext(0)
 	ctx.PushGlobalObject()
 	ctx.PushGoObject(SampleObject{42})
 	ctx.PutPropString(-2, "y")

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -6,6 +6,13 @@ import (
 	"testing"
 )
 
+func TestHeapLimit(t *testing.T) {
+	ctx := NewContext(256 * 1024)
+	defer ctx.DestroyHeap()
+	err := ctx.PevalString(`var buf = new Array(1024*1024); for (var i = 0; i < buf.length; i++) { buf[i] = 0; }`)
+	expect(t, err, 1)
+}
+
 func TestEvalString(t *testing.T) {
 	ctx := NewContext(0)
 	defer ctx.DestroyHeap()

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -1,7 +1,10 @@
 package duktape
 
-import "reflect"
-import "testing"
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
 
 func TestEvalString(t *testing.T) {
 	ctx := NewContext(0)
@@ -29,7 +32,7 @@ func TestEvalWith(t *testing.T) {
 	obj := MethodSuite{
 		"hi": func(d *Context) int {
 			x := d.GetInt(-2)
-			d.PushString("hi! " + string(48+x))
+			d.PushString("hi! " + strconv.Itoa(48+x))
 			return 1
 		},
 	}
@@ -38,7 +41,7 @@ func TestEvalWith(t *testing.T) {
 
 	actual := ctx.GetString(-1)
 
-	expect(t, actual, "hi! 2")
+	expect(t, actual, "hi! 50")
 }
 
 // from duktape examples

--- a/duktape_test.go
+++ b/duktape_test.go
@@ -11,7 +11,6 @@ func TestEvalString(t *testing.T) {
 	ctx.DestroyHeap()
 }
 
-
 func TestEvalFunc(t *testing.T) {
 	ctx := NewContext()
 	ctx.PevalString(`(function (x) { return x + x; })`)
@@ -29,7 +28,7 @@ func TestEvalWith(t *testing.T) {
 	obj := MethodSuite{
 		"hi": func(d *Context) int {
 			x := d.GetInt(-2)
-			d.PushString("hi! " + string(48 + x))
+			d.PushString("hi! " + string(48+x))
 			return 1
 		},
 	}
@@ -43,9 +42,7 @@ func TestEvalWith(t *testing.T) {
 	ctx.DestroyHeap()
 }
 
-
 // from duktape examples
-
 
 func TestMyAddTwo(t *testing.T) {
 	obj := MethodSuite{
@@ -72,7 +69,6 @@ func TestMyAddTwo(t *testing.T) {
 	expect(t, res, float64(5))
 	ctx.DestroyHeap()
 }
-
 
 func TestGoClosure(t *testing.T) {
 	sharedState := 0
@@ -113,11 +109,11 @@ type SampleObject struct {
 }
 
 func TestGoObject(t *testing.T) {
- 	ctx := NewContext()
+	ctx := NewContext()
 	ctx.PushGlobalObject()
 	ctx.PushGoObject(SampleObject{42})
- 	ctx.PutPropString(-2, "y")
- 	ctx.Pop()
+	ctx.PutPropString(-2, "y")
+	ctx.Pop()
 	obj := MethodSuite{
 		"tst": func(d *Context) int {
 			so := d.GetGoObject(-1).(SampleObject)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wirenboard/go-duktape
+
+go 1.20

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,1 +1,0 @@
-box: yosssi/golang-latest@1.0.7


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
duktape позволяет использовать кастомный менеджмент памяти, для этого при создании heap передаются кастомные alloc/realloc/free функции. Добавлена возможность ограничить максимальный размер heap. Необходимо для https://github.com/wirenboard/wb-rules/pull/192

Пример https://github.com/svaarala/duktape/blob/50af773b1b32067170786c2b7c661705ec7425d4/examples/sandbox/sandbox.c
___________________________________
**Что поменялось для пользователей:**
См https://github.com/wirenboard/wb-rules/pull/192

___________________________________
**Как проверял/а:**
См https://github.com/wirenboard/wb-rules/pull/192

